### PR TITLE
New package: encryptpad-0.5.0.1

### DIFF
--- a/srcpkgs/encryptpad/template
+++ b/srcpkgs/encryptpad/template
@@ -1,0 +1,28 @@
+# Template file for 'encryptpad'
+pkgname=encryptpad
+version=0.5.0.1
+revision=1
+wrksrc=EncryptPad-${version}
+build_style=configure
+configure_script="./configure.py"
+hostmakedepends="pkg-config python3"
+makedepends="botan-devel bzip2-devel qt5-devel zlib-devel"
+short_desc="Minimalist secure text editor and file encryptor"
+maintainer="Zyxer Zyxani <zyxerzyxani@cryptolab.net>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/evpo/EncryptPad"
+distfiles="https://github.com/evpo/EncryptPad/archive/v${version}.tar.gz"
+checksum=8518864441d25df58e12d9d400d256a7ae1ff20dc9037954a0c8298d4d1211f5
+changelog=https://raw.githubusercontent.com/evpo/EncryptPad/master/CHANGES.htm
+
+do_install() {
+	vbin bin/release/encryptcli
+	vbin bin/release/encryptpad
+
+	vinstall encryptpad.desktop 644 usr/share/applications
+	vinstall encryptpad.xml 644 usr/share/mime/packages
+
+	for res in 16x16 32x32 128x128; do
+		vinstall images/icns.iconset/icon_${res}.png 644 usr/share/icons/hicolor/${res}/apps encryptpad.png
+	done
+}


### PR DESCRIPTION
Encryptpad, basic text editor with support for symmetric encryption, protect documents with password or key file.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**|**briefly**|**NO**

#### New package
- This new package conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements): **YES**


<!-- Note: If the build is likely to take more than 2 hours, please add ci skip tag as described in
https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration
and test at least one native build and, if supported, at least one cross build.
Ignore this section if this PR is not skipping CI.
-->

#### Local build testing
- I built this PR locally for my native architecture, (x86_64-glibc)
- I built this PR locally for these architectures (if supported. mark crossbuilds):

